### PR TITLE
updated packageJSON to include command for using seeder file

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "node server.js",
     "lint": "eslint --quiet .",
     "lint:fix": "eslint --fix .",
-    "test": "npm run lint && cross-env NODE_ENV=test mocha --reporter spec --exit"
+    "test": "npm run lint && cross-env NODE_ENV=test mocha --reporter spec --exit",
+    "seed": "npx sequelize-cli db:seed:all"
   },
   "license": "ISC",
   "dependencies": {


### PR DESCRIPTION
Tim helped me add a line in the package.json file with the following command that allows you to use the two files in the seeder folder to seed the database:
npx sequelize-cli db:seed:all

This will add the 20 horses and 13 owners to your local database. To get rid of anything already in your database tables, in your MySQL Workbench, FIRST right click on each table and choose "truncate". Then type "npm run seed" in the command line.